### PR TITLE
Add Serilog structured logging with SigNoz observability via OTLP

### DIFF
--- a/Everlore.AppHost/AppHost.cs
+++ b/Everlore.AppHost/AppHost.cs
@@ -10,16 +10,44 @@ var everloretenantdb = postgres.AddDatabase("everloretenantdb");
 var cache = builder.AddGarnet("cache")
     .WithDataVolume();
 
+// SigNoz observability stack
+var clickhouse = builder.AddContainer("signoz-clickhouse", "clickhouse/clickhouse-server", "24.1")
+    .WithVolume("signoz-clickhouse-data", "/var/lib/clickhouse")
+    .WithEndpoint(port: 9000, targetPort: 9000, name: "native", scheme: "tcp")
+    .WithEndpoint(port: 8123, targetPort: 8123, name: "http");
+
+var signozCollector = builder.AddContainer("signoz-collector", "signoz/signoz-otel-collector", "0.111.0")
+    .WithBindMount("./signoz/otel-collector-config.yaml", "/etc/otel/config.yaml")
+    .WithEndpoint(port: 4317, targetPort: 4317, name: "grpc")
+    .WithEndpoint(port: 4318, targetPort: 4318, name: "http")
+    .WaitFor(clickhouse);
+
+var signozQueryService = builder.AddContainer("signoz-query-service", "signoz/query-service", "0.111.0")
+    .WithEndpoint(port: 8080, targetPort: 8080, name: "http")
+    .WithEnvironment("ClickHouseUrl", "tcp://signoz-clickhouse:9000")
+    .WithEnvironment("STORAGE", "clickhouse")
+    .WaitFor(clickhouse)
+    .WaitFor(signozCollector);
+
+var signozFrontend = builder.AddContainer("signoz-frontend", "signoz/frontend", "0.111.0")
+    .WithEndpoint(port: 3301, targetPort: 3301, name: "http")
+    .WithEnvironment("FRONTEND_API_ENDPOINT", "http://signoz-query-service:8080")
+    .WaitFor(signozQueryService);
+
 var migrations = builder.AddProject<Projects.Everlore_MigrationService>("migrations")
     .WithReference(everloredb)
     .WithReference(everloretenantdb)
+    .WithEnvironment("SIGNOZ_OTLP_ENDPOINT", signozCollector.GetEndpoint("grpc"))
     .WaitFor(everloredb)
-    .WaitFor(everloretenantdb);
+    .WaitFor(everloretenantdb)
+    .WaitFor(signozCollector);
 
 var sync = builder.AddProject<Projects.Everlore_SyncService>("sync")
     .WithReference(everloredb)
     .WithReference(everloretenantdb)
-    .WaitForCompletion(migrations);
+    .WithEnvironment("SIGNOZ_OTLP_ENDPOINT", signozCollector.GetEndpoint("grpc"))
+    .WaitForCompletion(migrations)
+    .WaitFor(signozCollector);
 
 builder.AddProject<Projects.Everlore_Api>("everlore-api")
     .WithReference(everloredb)
@@ -29,7 +57,9 @@ builder.AddProject<Projects.Everlore_Api>("everlore-api")
     .WithEnvironment("Jwt__Audience", "Everlore")
     .WithEnvironment("Jwt__ExpirationMinutes", "60")
     .WithEnvironment("Registration__Mode", "Open")
+    .WithEnvironment("SIGNOZ_OTLP_ENDPOINT", signozCollector.GetEndpoint("grpc"))
     .WaitForCompletion(sync)
-    .WaitFor(cache);
+    .WaitFor(cache)
+    .WaitFor(signozCollector);
 
 builder.Build().Run();

--- a/Everlore.AppHost/signoz/otel-collector-config.yaml
+++ b/Everlore.AppHost/signoz/otel-collector-config.yaml
@@ -1,0 +1,58 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    send_batch_size: 10000
+    send_batch_max_size: 11000
+    timeout: 10s
+
+connectors:
+  signozspanmetrics/delta: {}
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+exporters:
+  clickhousetraces:
+    datasource: tcp://signoz-clickhouse:9000/signoz_traces
+    use_new_schema: true
+
+  signozclickhousemetrics:
+    dsn: tcp://signoz-clickhouse:9000/signoz_metrics
+    enable_exp_histogram: true
+
+  clickhouselogsexporter:
+    dsn: tcp://signoz-clickhouse:9000/signoz_logs
+    timeout: 10s
+    use_new_schema: true
+
+  signozclickhousemeter:
+    dsn: tcp://signoz-clickhouse:9000/signoz_meter
+    timeout: 45s
+
+service:
+  extensions: [health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [signozspanmetrics/delta, batch]
+      exporters: [clickhousetraces]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [signozclickhousemetrics]
+    metrics/spanmetrics:
+      receivers: [signozspanmetrics/delta]
+      processors: [batch]
+      exporters: [signozclickhousemetrics]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [clickhouselogsexporter]

--- a/Everlore.MigrationService/Program.cs
+++ b/Everlore.MigrationService/Program.cs
@@ -8,8 +8,6 @@ var builder = Host.CreateApplicationBuilder(args);
 
 builder.AddServiceDefaults();
 
-builder.Logging.AddFilter("Microsoft.EntityFrameworkCore.Database.Command", LogLevel.Critical);
-
 var catalogConnectionString = builder.Configuration.GetConnectionString("everloredb")
     ?? throw new InvalidOperationException("Connection string 'everloredb' not found.");
 

--- a/Everlore.MigrationService/appsettings.json
+++ b/Everlore.MigrationService/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Serilog": {
+    "MinimumLevel": {
+      "Override": {
+        "Microsoft.EntityFrameworkCore.Database.Command": "Fatal"
+      }
+    }
+  }
+}

--- a/Everlore.ServiceDefaults/Everlore.ServiceDefaults.csproj
+++ b/Everlore.ServiceDefaults/Everlore.ServiceDefaults.csproj
@@ -13,6 +13,11 @@
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.3.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.3.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+    <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Everlore is a self-hostable BI tool designed for companies that want Power BI-st
 |-------|-----------|
 | Domain & API | .NET 10, ASP.NET Core, Entity Framework Core |
 | Orchestration | .NET Aspire |
+| Logging | Serilog (structured logging, OTLP export) |
+| Observability | SigNoz (self-hosted) via OpenTelemetry |
 | Database | PostgreSQL (catalog + per-tenant) |
 | Frontend | React, Next.js, TypeScript |
 | AI | Provider-agnostic (OpenAI, Anthropic, Ollama, vLLM) |
@@ -40,8 +42,8 @@ Everlore.slnx
 ├── Everlore.Connector.Seed            # Deterministic test data generator
 ├── Everlore.SyncService               # Background data sync worker
 ├── Everlore.MigrationService          # EF migrations + dev data seeding
-├── Everlore.AppHost                   # .NET Aspire orchestrator (Postgres + Garnet)
-└── Everlore.ServiceDefaults           # Shared Aspire configuration
+├── Everlore.AppHost                   # .NET Aspire orchestrator (Postgres + Garnet + SigNoz)
+└── Everlore.ServiceDefaults           # Shared Aspire configuration (Serilog, OpenTelemetry)
 ```
 
 ### Architecture
@@ -79,11 +81,13 @@ Everlore.slnx
    dotnet run --project Everlore.AppHost
    ```
 
-   This starts Postgres, runs migrations, seeds a dev tenant with test data, and launches the API.
+   This starts Postgres, Garnet, SigNoz (ClickHouse + Collector + Query Service + Frontend), runs migrations, seeds a dev tenant with test data, and launches the API.
 
 4. Open the Aspire dashboard (URL shown in terminal output) to see all services.
 
-5. The API is available with Swagger UI at the everlore-api endpoint.
+5. Open SigNoz at `http://localhost:3301` for logs, traces, and metrics.
+
+6. The API is available with Swagger UI at the everlore-api endpoint.
 
 ### Dev Credentials
 
@@ -124,6 +128,8 @@ Phase 1 (Platform Hardening) is complete. Phase 2 (Reporting API) is in progress
 - Real-time query progress via SignalR
 - Garnet (Redis-compatible) cache for schema and query results
 - Polly resilience (retry + circuit breaker) on external DB connections
+- Serilog structured logging with OTLP export to Aspire Dashboard and SigNoz
+- SigNoz observability stack (ClickHouse, OTel Collector, Query Service, Frontend) as Aspire containers
 
 See [ROADMAP.md](ROADMAP.md) for the full development plan with detailed progress.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -115,6 +115,8 @@ The core product. Users connect to external databases, browse schemas, build que
 - [x] Polly resilience: retry (3 attempts, exponential backoff), circuit breaker (50% failure ratio, 30s break), 30s timeout
 - [x] Garnet (Redis-compatible) cache via Aspire with data volume
 - [x] TenantRequiredMiddleware expanded to guard /graphql and /hubs paths
+- [x] Serilog structured logging: Console sink + dual OTLP sinks (Aspire Dashboard + SigNoz)
+- [x] SigNoz observability stack as Aspire container resources (ClickHouse, OTel Collector, Query Service, Frontend)
 
 ### 2.8 Export — not started
 - CSV and Excel export from query results
@@ -284,6 +286,8 @@ The query model and execution engine from Phase 2 are the single most important 
 |-------|-----------|
 | Domain & API | .NET 10, ASP.NET Core, Entity Framework Core |
 | Query Engine | Dapper, HotChocolate (GraphQL), Polly |
+| Logging | Serilog (structured logging, OTLP export) |
+| Observability | SigNoz (self-hosted), OpenTelemetry, Aspire Dashboard |
 | Cache | Garnet (Redis-compatible) via Aspire |
 | Real-time | SignalR with Redis backplane |
 | Orchestration | .NET Aspire |
@@ -309,5 +313,5 @@ The query model and execution engine from Phase 2 are the single most important 
 | `Everlore.Connector.Seed` | Deterministic test data generator |
 | `Everlore.SyncService` | Background sync worker |
 | `Everlore.MigrationService` | EF migrations + dev data seeding |
-| `Everlore.AppHost` | Aspire orchestrator (Postgres + Garnet) |
-| `Everlore.ServiceDefaults` | Shared Aspire config |
+| `Everlore.AppHost` | Aspire orchestrator (Postgres + Garnet + SigNoz) |
+| `Everlore.ServiceDefaults` | Shared Aspire config (Serilog, OpenTelemetry) |


### PR DESCRIPTION
Replace default .NET logging with Serilog (Console + dual OTLP sinks for Aspire Dashboard and SigNoz). Add SigNoz stack as Aspire container resources (ClickHouse, OTel Collector, Query Service, Frontend) with SIGNOZ_OTLP_ENDPOINT wired to all service projects.