### PR TITLE
Fix SigNoz container images and OTel exporter conflict

### DIFF
--- a/Everlore.AppHost/signoz/clickhouse-cluster.xml
+++ b/Everlore.AppHost/signoz/clickhouse-cluster.xml
@@ -1,0 +1,22 @@
+<clickhouse>
+    <macros>
+        <shard>1</shard>
+        <replica>signoz-clickhouse</replica>
+    </macros>
+    <remote_servers>
+        <cluster>
+            <shard>
+                <replica>
+                    <host>signoz-clickhouse</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </cluster>
+    </remote_servers>
+    <zookeeper>
+        <node>
+            <host>signoz-zookeeper</host>
+            <port>2181</port>
+        </node>
+    </zookeeper>
+</clickhouse>

--- a/Everlore.AppHost/signoz/otel-collector-config.yaml
+++ b/Everlore.AppHost/signoz/otel-collector-config.yaml
@@ -11,9 +11,24 @@ processors:
     send_batch_size: 10000
     send_batch_max_size: 11000
     timeout: 10s
+  signozspanmetrics/delta:
+    metrics_exporter: signozclickhousemetrics
+    metrics_flush_interval: 60s
+    latency_histogram_buckets: [100us, 1ms, 2ms, 6ms, 10ms, 50ms, 100ms, 250ms, 500ms, 1000ms, 1400ms, 2000ms, 5s, 10s, 20s, 40s, 60s]
+    aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+    enable_exp_histogram: true
+    dimensions:
+      - name: service.namespace
+        default: default
+      - name: deployment.environment
+        default: default
 
 connectors:
-  signozspanmetrics/delta: {}
+  signozmeter:
+    metrics_flush_interval: 1h
+    dimensions:
+      - name: service.name
+      - name: deployment.environment
 
 extensions:
   health_check:
@@ -22,11 +37,11 @@ extensions:
 exporters:
   clickhousetraces:
     datasource: tcp://signoz-clickhouse:9000/signoz_traces
+    low_cardinal_exception_grouping: ${env:LOW_CARDINAL_EXCEPTION_GROUPING}
     use_new_schema: true
 
   signozclickhousemetrics:
     dsn: tcp://signoz-clickhouse:9000/signoz_metrics
-    enable_exp_histogram: true
 
   clickhouselogsexporter:
     dsn: tcp://signoz-clickhouse:9000/signoz_logs
@@ -37,22 +52,29 @@ exporters:
     dsn: tcp://signoz-clickhouse:9000/signoz_meter
     timeout: 45s
 
+  metadataexporter:
+    cache:
+      provider: in_memory
+    dsn: tcp://signoz-clickhouse:9000/signoz_metadata
+    enabled: true
+    timeout: 45s
+
 service:
   extensions: [health_check]
   pipelines:
     traces:
       receivers: [otlp]
       processors: [signozspanmetrics/delta, batch]
-      exporters: [clickhousetraces]
+      exporters: [clickhousetraces, metadataexporter, signozmeter]
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [signozclickhousemetrics]
-    metrics/spanmetrics:
-      receivers: [signozspanmetrics/delta]
-      processors: [batch]
-      exporters: [signozclickhousemetrics]
+      exporters: [signozclickhousemetrics, metadataexporter, signozmeter]
     logs:
       receivers: [otlp]
       processors: [batch]
-      exporters: [clickhouselogsexporter]
+      exporters: [clickhouselogsexporter, metadataexporter, signozmeter]
+    metrics/meter:
+      receivers: [signozmeter]
+      processors: [batch]
+      exporters: [signozclickhousemeter]

--- a/Everlore.ServiceDefaults/Extensions.cs
+++ b/Everlore.ServiceDefaults/Extensions.cs
@@ -77,22 +77,24 @@ public static class Extensions
 
     private static TBuilder AddOpenTelemetryExporters<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
     {
-        var useOtlpExporter = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
-
-        if (useOtlpExporter)
-        {
-            builder.Services.AddOpenTelemetry().UseOtlpExporter();
-        }
-
+        var aspireEndpoint = builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"];
         var signozEndpoint = builder.Configuration["SIGNOZ_OTLP_ENDPOINT"];
-        if (!string.IsNullOrWhiteSpace(signozEndpoint))
-        {
-            builder.Services.AddOpenTelemetry()
-                .WithTracing(tracing => tracing.AddOtlpExporter("signoz", o =>
-                    o.Endpoint = new Uri(signozEndpoint)))
-                .WithMetrics(metrics => metrics.AddOtlpExporter("signoz", o =>
-                    o.Endpoint = new Uri(signozEndpoint)));
-        }
+
+        builder.Services.AddOpenTelemetry()
+            .WithTracing(tracing =>
+            {
+                if (!string.IsNullOrWhiteSpace(aspireEndpoint))
+                    tracing.AddOtlpExporter("aspire", o => o.Endpoint = new Uri(aspireEndpoint));
+                if (!string.IsNullOrWhiteSpace(signozEndpoint))
+                    tracing.AddOtlpExporter("signoz", o => o.Endpoint = new Uri(signozEndpoint));
+            })
+            .WithMetrics(metrics =>
+            {
+                if (!string.IsNullOrWhiteSpace(aspireEndpoint))
+                    metrics.AddOtlpExporter("aspire", o => o.Endpoint = new Uri(aspireEndpoint));
+                if (!string.IsNullOrWhiteSpace(signozEndpoint))
+                    metrics.AddOtlpExporter("signoz", o => o.Endpoint = new Uri(signozEndpoint));
+            });
 
         return builder;
     }


### PR DESCRIPTION
Replace deprecated signoz/query-service + signoz/frontend with unified signoz/signoz:v0.112.1 image. Update collector to v0.142.1 with self-migrating entrypoint. Add ZooKeeper and ClickHouse cluster config for ON CLUSTER DDL support. Update collector config to match official v0.142.1 format with metadataexporter and signozmeter connector.

Fix UseOtlpExporter/AddOtlpExporter conflict by using signal-specific exporters for both Aspire and SigNoz endpoints.