### PR TITLE
Gateway hardening, GraphQL routing, tenant DB CRUD proxying

### DIFF
--- a/Everlore.Api/Controllers/CrudController.cs
+++ b/Everlore.Api/Controllers/CrudController.cs
@@ -1,4 +1,3 @@
-using Everlore.Application.Common.Extensions;
 using Everlore.Application.Common.Models;
 using Everlore.Domain.Common;
 using Microsoft.AspNetCore.Mvc;
@@ -20,17 +19,8 @@ public abstract class CrudController<T>(IRepository<T> repository) : ApiControll
         CancellationToken ct)
     {
         var filters = ExtractFilters();
-        var query = repository.Query();
-
-        if (!string.IsNullOrWhiteSpace(after))
-        {
-            var cursorQuery = new CursorPaginationQuery(
-                pagination.PageSize, after, pagination.SortBy, pagination.SortDir);
-            var cursorResult = await query.ToCursorPagedResultAsync(cursorQuery, filters, ct);
-            return Ok(cursorResult);
-        }
-
-        var result = await query.ToPagedResultAsync(pagination, filters, ct);
+        var result = await repository.GetAllPagedAsync(
+            pagination.Page, pagination.PageSize, pagination.SortBy, pagination.SortDir, after, filters, ct);
         return Ok(result);
     }
 

--- a/Everlore.Api/Gateway/GatewayConnectionTracker.cs
+++ b/Everlore.Api/Gateway/GatewayConnectionTracker.cs
@@ -35,9 +35,18 @@ public class GatewayConnectionTracker : IGatewayConnectionTracker
         }
     }
 
-    public bool IsAgentOnline(Guid tenantId)
+    public bool IsAgentOnline(Guid tenantId) => IsAgentHealthy(tenantId);
+
+    public bool IsAgentHealthy(Guid tenantId)
     {
-        return _tenantToConnection.ContainsKey(tenantId);
+        if (!_tenantToConnection.TryGetValue(tenantId, out var connectionId))
+            return false;
+
+        if (!_connections.TryGetValue(connectionId, out var info))
+            return false;
+
+        // 3x the 30s heartbeat interval
+        return (DateTime.UtcNow - info.LastHeartbeatAt) < TimeSpan.FromSeconds(90);
     }
 
     public GatewayAgentInfo? GetAgentInfo(Guid tenantId)

--- a/Everlore.Api/Gateway/GatewayCrudService.cs
+++ b/Everlore.Api/Gateway/GatewayCrudService.cs
@@ -1,0 +1,29 @@
+using Everlore.Gateway.Contracts.Messages;
+using Everlore.Api.Hubs;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Everlore.Api.Gateway;
+
+public class GatewayCrudService(
+    IGatewayConnectionTracker connectionTracker,
+    IGatewayResponseCorrelator responseCorrelator,
+    IHubContext<GatewayHub, Everlore.Gateway.Contracts.IGatewayHubClient> hubContext,
+    ILogger<GatewayCrudService> logger)
+{
+    private static readonly TimeSpan GatewayTimeout = TimeSpan.FromSeconds(60);
+
+    public async Task<GatewayCrudResponse> SendAsync(Guid tenantId, GatewayCrudRequest request, CancellationToken ct = default)
+    {
+        if (!connectionTracker.IsAgentOnline(tenantId))
+            throw new InvalidOperationException("Gateway agent is not connected for this tenant. Cannot execute CRUD operation on self-hosted tenant.");
+
+        responseCorrelator.RegisterRequestTenant(request.RequestId, tenantId);
+
+        logger.LogInformation("Routing CRUD {Operation} {EntityType} {RequestId} to gateway agent for tenant {TenantId}",
+            request.Operation, request.EntityType, request.RequestId, tenantId);
+
+        await hubContext.Clients.Group($"gateway:{tenantId}").ExecuteCrud(request);
+
+        return await responseCorrelator.WaitForCrudResponseAsync(request.RequestId, GatewayTimeout, ct);
+    }
+}

--- a/Everlore.Api/Gateway/GatewayExploreService.cs
+++ b/Everlore.Api/Gateway/GatewayExploreService.cs
@@ -1,0 +1,65 @@
+using System.Text.Json;
+using Everlore.Application.Common.Interfaces;
+using Everlore.Domain.Tenancy;
+using Everlore.Gateway.Contracts.Messages;
+using Everlore.Api.Hubs;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Everlore.Api.Gateway;
+
+public class GatewayExploreService(
+    IExploreService inner,
+    ICatalogDbContext db,
+    IGatewayConnectionTracker connectionTracker,
+    IGatewayResponseCorrelator responseCorrelator,
+    IHubContext<GatewayHub, Everlore.Gateway.Contracts.IGatewayHubClient> hubContext,
+    ICurrentUser currentUser,
+    ILogger<GatewayExploreService> logger) : IExploreService
+{
+    private static readonly TimeSpan GatewayTimeout = TimeSpan.FromSeconds(60);
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    public async Task<IReadOnlyList<Dictionary<string, object?>>> ExploreAsync(
+        Guid dataSourceId, int dataSourceType, string sql, CancellationToken ct = default)
+    {
+        var tenantId = currentUser.TenantId;
+        if (tenantId is null || !await IsSelfHostedAsync(tenantId.Value, ct))
+            return await inner.ExploreAsync(dataSourceId, dataSourceType, sql, ct);
+
+        return await RouteExploreThroughGateway(tenantId.Value, dataSourceId, dataSourceType, sql, ct);
+    }
+
+    private async Task<IReadOnlyList<Dictionary<string, object?>>> RouteExploreThroughGateway(
+        Guid tenantId, Guid dataSourceId, int dataSourceType, string sql, CancellationToken ct)
+    {
+        if (!connectionTracker.IsAgentOnline(tenantId))
+            throw new InvalidOperationException("Gateway agent is not connected for this tenant. Cannot execute explore query on self-hosted data source.");
+
+        var requestId = Guid.NewGuid().ToString("N");
+        var request = new GatewayExploreRequest(requestId, dataSourceId, dataSourceType, sql);
+
+        responseCorrelator.RegisterRequestTenant(requestId, tenantId);
+
+        logger.LogInformation("Routing explore {RequestId} to gateway agent for tenant {TenantId}, data source {DataSourceId}",
+            requestId, tenantId, dataSourceId);
+
+        await hubContext.Clients.Group($"gateway:{tenantId}").Explore(request);
+
+        var response = await responseCorrelator.WaitForExploreResponseAsync(requestId, GatewayTimeout, ct);
+
+        if (!response.Success)
+            throw new InvalidOperationException($"Gateway explore failed: {response.Error}");
+
+        return JsonSerializer.Deserialize<List<Dictionary<string, object?>>>(response.ResultJson!, JsonOptions) ?? [];
+    }
+
+    private async Task<bool> IsSelfHostedAsync(Guid tenantId, CancellationToken ct)
+    {
+        var tenant = await db.Tenants
+            .AsNoTracking()
+            .FirstOrDefaultAsync(t => t.Id == tenantId, ct);
+
+        return tenant?.HostingMode == HostingMode.SelfHosted;
+    }
+}

--- a/Everlore.Api/Gateway/GatewayRepository.cs
+++ b/Everlore.Api/Gateway/GatewayRepository.cs
@@ -1,0 +1,137 @@
+using System.Text.Json;
+using Everlore.Application.Common.Interfaces;
+using Everlore.Domain.Common;
+using Everlore.Domain.Tenancy;
+using Everlore.Gateway.Contracts.Messages;
+using Microsoft.EntityFrameworkCore;
+
+namespace Everlore.Api.Gateway;
+
+public class GatewayRepository<T>(
+    IRepository<T> inner,
+    ICatalogDbContext catalogDb,
+    ICurrentUser currentUser,
+    GatewayCrudService crudService,
+    ILogger<GatewayRepository<T>> logger) : IRepository<T> where T : BaseEntity
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly ILogger<GatewayRepository<T>> _logger = logger;
+    private readonly List<(CrudOperation Op, T Entity)> _pending = [];
+
+    public async Task<T?> GetByIdAsync(Guid id, CancellationToken ct = default)
+    {
+        if (!await IsSelfHostedAsync(ct))
+            return await inner.GetByIdAsync(id, ct);
+
+        var tenantId = currentUser.TenantId!.Value;
+        var requestId = Guid.NewGuid().ToString("N");
+        var request = new GatewayCrudRequest(requestId, typeof(T).Name, CrudOperation.GetById, id, null, null, null);
+
+        var response = await crudService.SendAsync(tenantId, request, ct);
+
+        if (!response.Success)
+        {
+            if (response.StatusCode == 404) return null;
+            throw new InvalidOperationException($"Gateway CRUD GetById failed: {response.Error}");
+        }
+
+        return JsonSerializer.Deserialize<T>(response.ResultJson!, JsonOptions);
+    }
+
+    public async Task<IReadOnlyList<T>> GetAllAsync(CancellationToken ct = default)
+    {
+        if (!await IsSelfHostedAsync(ct))
+            return await inner.GetAllAsync(ct);
+
+        // For self-hosted, use GetAllPaged with large page size
+        var result = await GetAllPagedAsync(1, 100, null, "asc", null, null, ct);
+        // Extract items from the paged result
+        var json = JsonSerializer.Serialize(result, JsonOptions);
+        using var doc = JsonDocument.Parse(json);
+        var itemsJson = doc.RootElement.GetProperty("items").GetRawText();
+        return JsonSerializer.Deserialize<List<T>>(itemsJson, JsonOptions) ?? [];
+    }
+
+    public IQueryable<T> Query()
+    {
+        // IQueryable can't be proxied over SignalR — this is only used for SaasHosted
+        return inner.Query();
+    }
+
+    public Task<int> CountAsync(CancellationToken ct = default) => inner.CountAsync(ct);
+
+    public void Add(T entity) => _pending.Add((CrudOperation.Create, entity));
+
+    public void Update(T entity) => _pending.Add((CrudOperation.Update, entity));
+
+    public void Remove(T entity) => _pending.Add((CrudOperation.Delete, entity));
+
+    public void SetValues(T existing, T incoming) => inner.SetValues(existing, incoming);
+
+    public async Task<int> SaveChangesAsync(CancellationToken ct = default)
+    {
+        if (!await IsSelfHostedAsync(ct) || _pending.Count == 0)
+            return await inner.SaveChangesAsync(ct);
+
+        var tenantId = currentUser.TenantId!.Value;
+        var count = 0;
+
+        foreach (var (op, entity) in _pending)
+        {
+            var requestId = Guid.NewGuid().ToString("N");
+            var entityJson = JsonSerializer.Serialize(entity, entity.GetType(), JsonOptions);
+            var request = new GatewayCrudRequest(requestId, typeof(T).Name, op, entity.Id, entityJson, null, null);
+
+            var response = await crudService.SendAsync(tenantId, request, ct);
+
+            if (!response.Success)
+                throw new InvalidOperationException($"Gateway CRUD {op} failed: {response.Error}");
+
+            count++;
+        }
+
+        _pending.Clear();
+        return count;
+    }
+
+    public async Task<object> GetAllPagedAsync(int page, int pageSize, string? sortBy, string sortDir,
+        string? after, IDictionary<string, string>? filters, CancellationToken ct = default)
+    {
+        if (!await IsSelfHostedAsync(ct))
+            return await inner.GetAllPagedAsync(page, pageSize, sortBy, sortDir, after, filters, ct);
+
+        var tenantId = currentUser.TenantId!.Value;
+        var requestId = Guid.NewGuid().ToString("N");
+
+        var paginationParams = new GatewayCrudPaginationParams(
+            page, pageSize, sortBy, sortDir, after,
+            filters?.ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
+
+        var paginationJson = JsonSerializer.Serialize(paginationParams, JsonOptions);
+        var request = new GatewayCrudRequest(requestId, typeof(T).Name, CrudOperation.GetAll, null, null, paginationJson, after);
+
+        var response = await crudService.SendAsync(tenantId, request, ct);
+
+        if (!response.Success)
+            throw new InvalidOperationException($"Gateway CRUD GetAll failed: {response.Error}");
+
+        return JsonSerializer.Deserialize<object>(response.ResultJson!, JsonOptions)!;
+    }
+
+    private async Task<bool> IsSelfHostedAsync(CancellationToken ct)
+    {
+        var tenantId = currentUser.TenantId;
+        if (tenantId is null) return false;
+
+        var tenant = await catalogDb.Tenants
+            .AsNoTracking()
+            .FirstOrDefaultAsync(t => t.Id == tenantId.Value, ct);
+
+        return tenant?.HostingMode == HostingMode.SelfHosted;
+    }
+}

--- a/Everlore.Api/Gateway/GatewayResponseCorrelator.cs
+++ b/Everlore.Api/Gateway/GatewayResponseCorrelator.cs
@@ -1,12 +1,15 @@
 using System.Collections.Concurrent;
 using Everlore.Gateway.Contracts.Messages;
+using Microsoft.Extensions.Logging;
 
 namespace Everlore.Api.Gateway;
 
-public class GatewayResponseCorrelator : IGatewayResponseCorrelator
+public class GatewayResponseCorrelator(ILogger<GatewayResponseCorrelator> logger) : IGatewayResponseCorrelator
 {
     private readonly ConcurrentDictionary<string, TaskCompletionSource<GatewayExecuteQueryResponse>> _queryWaiters = new();
     private readonly ConcurrentDictionary<string, TaskCompletionSource<GatewayDiscoverSchemaResponse>> _schemaWaiters = new();
+    private readonly ConcurrentDictionary<string, TaskCompletionSource<GatewayExploreResponse>> _exploreWaiters = new();
+    private readonly ConcurrentDictionary<string, TaskCompletionSource<GatewayCrudResponse>> _crudWaiters = new();
     private readonly ConcurrentDictionary<string, Guid> _requestToTenant = new();
 
     public async Task<GatewayExecuteQueryResponse> WaitForQueryResponseAsync(
@@ -14,6 +17,9 @@ public class GatewayResponseCorrelator : IGatewayResponseCorrelator
     {
         var tcs = new TaskCompletionSource<GatewayExecuteQueryResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
         _queryWaiters[requestId] = tcs;
+
+        logger.LogInformation("Registered query waiter for request {RequestId} (timeout={TimeoutSeconds}s)",
+            requestId, timeout.TotalSeconds);
 
         try
         {
@@ -27,6 +33,8 @@ public class GatewayResponseCorrelator : IGatewayResponseCorrelator
         }
         catch (OperationCanceledException) when (!ct.IsCancellationRequested)
         {
+            logger.LogWarning("Query request {RequestId} timed out after {TimeoutSeconds}s",
+                requestId, timeout.TotalSeconds);
             throw new TimeoutException($"Gateway agent did not respond within {timeout.TotalSeconds}s for request {requestId}.");
         }
         finally
@@ -42,6 +50,9 @@ public class GatewayResponseCorrelator : IGatewayResponseCorrelator
         var tcs = new TaskCompletionSource<GatewayDiscoverSchemaResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
         _schemaWaiters[requestId] = tcs;
 
+        logger.LogInformation("Registered schema waiter for request {RequestId} (timeout={TimeoutSeconds}s)",
+            requestId, timeout.TotalSeconds);
+
         try
         {
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
@@ -54,6 +65,8 @@ public class GatewayResponseCorrelator : IGatewayResponseCorrelator
         }
         catch (OperationCanceledException) when (!ct.IsCancellationRequested)
         {
+            logger.LogWarning("Schema request {RequestId} timed out after {TimeoutSeconds}s",
+                requestId, timeout.TotalSeconds);
             throw new TimeoutException($"Gateway agent did not respond within {timeout.TotalSeconds}s for request {requestId}.");
         }
         finally
@@ -63,11 +76,48 @@ public class GatewayResponseCorrelator : IGatewayResponseCorrelator
         }
     }
 
+    public async Task<GatewayExploreResponse> WaitForExploreResponseAsync(
+        string requestId, TimeSpan timeout, CancellationToken ct = default)
+    {
+        var tcs = new TaskCompletionSource<GatewayExploreResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _exploreWaiters[requestId] = tcs;
+
+        logger.LogInformation("Registered explore waiter for request {RequestId} (timeout={TimeoutSeconds}s)",
+            requestId, timeout.TotalSeconds);
+
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(timeout);
+
+            await using var registration = cts.Token.Register(() =>
+                tcs.TrySetCanceled(cts.Token));
+
+            return await tcs.Task;
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            logger.LogWarning("Explore request {RequestId} timed out after {TimeoutSeconds}s",
+                requestId, timeout.TotalSeconds);
+            throw new TimeoutException($"Gateway agent did not respond within {timeout.TotalSeconds}s for request {requestId}.");
+        }
+        finally
+        {
+            _exploreWaiters.TryRemove(requestId, out _);
+            _requestToTenant.TryRemove(requestId, out _);
+        }
+    }
+
     public void CompleteQueryResponse(string requestId, GatewayExecuteQueryResponse response)
     {
         if (_queryWaiters.TryRemove(requestId, out var tcs))
         {
+            logger.LogInformation("Completed query response for request {RequestId}", requestId);
             tcs.TrySetResult(response);
+        }
+        else
+        {
+            logger.LogWarning("Received orphaned query response for request {RequestId} (no waiter)", requestId);
         }
     }
 
@@ -75,12 +125,77 @@ public class GatewayResponseCorrelator : IGatewayResponseCorrelator
     {
         if (_schemaWaiters.TryRemove(requestId, out var tcs))
         {
+            logger.LogInformation("Completed schema response for request {RequestId}", requestId);
             tcs.TrySetResult(response);
+        }
+        else
+        {
+            logger.LogWarning("Received orphaned schema response for request {RequestId} (no waiter)", requestId);
+        }
+    }
+
+    public void CompleteExploreResponse(string requestId, GatewayExploreResponse response)
+    {
+        if (_exploreWaiters.TryRemove(requestId, out var tcs))
+        {
+            logger.LogInformation("Completed explore response for request {RequestId}", requestId);
+            tcs.TrySetResult(response);
+        }
+        else
+        {
+            logger.LogWarning("Received orphaned explore response for request {RequestId} (no waiter)", requestId);
+        }
+    }
+
+    public async Task<GatewayCrudResponse> WaitForCrudResponseAsync(
+        string requestId, TimeSpan timeout, CancellationToken ct = default)
+    {
+        var tcs = new TaskCompletionSource<GatewayCrudResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _crudWaiters[requestId] = tcs;
+
+        logger.LogInformation("Registered CRUD waiter for request {RequestId} (timeout={TimeoutSeconds}s)",
+            requestId, timeout.TotalSeconds);
+
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(timeout);
+
+            await using var registration = cts.Token.Register(() =>
+                tcs.TrySetCanceled(cts.Token));
+
+            return await tcs.Task;
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            logger.LogWarning("CRUD request {RequestId} timed out after {TimeoutSeconds}s",
+                requestId, timeout.TotalSeconds);
+            throw new TimeoutException($"Gateway agent did not respond within {timeout.TotalSeconds}s for request {requestId}.");
+        }
+        finally
+        {
+            _crudWaiters.TryRemove(requestId, out _);
+            _requestToTenant.TryRemove(requestId, out _);
+        }
+    }
+
+    public void CompleteCrudResponse(string requestId, GatewayCrudResponse response)
+    {
+        if (_crudWaiters.TryRemove(requestId, out var tcs))
+        {
+            logger.LogInformation("Completed CRUD response for request {RequestId}", requestId);
+            tcs.TrySetResult(response);
+        }
+        else
+        {
+            logger.LogWarning("Received orphaned CRUD response for request {RequestId} (no waiter)", requestId);
         }
     }
 
     public void FailRequest(string requestId, string error)
     {
+        logger.LogInformation("Failing request {RequestId}: {Error}", requestId, error);
+
         if (_queryWaiters.TryRemove(requestId, out var queryTcs))
         {
             queryTcs.TrySetException(new InvalidOperationException($"Gateway error: {error}"));
@@ -89,6 +204,16 @@ public class GatewayResponseCorrelator : IGatewayResponseCorrelator
         if (_schemaWaiters.TryRemove(requestId, out var schemaTcs))
         {
             schemaTcs.TrySetException(new InvalidOperationException($"Gateway error: {error}"));
+        }
+
+        if (_exploreWaiters.TryRemove(requestId, out var exploreTcs))
+        {
+            exploreTcs.TrySetException(new InvalidOperationException($"Gateway error: {error}"));
+        }
+
+        if (_crudWaiters.TryRemove(requestId, out var crudTcs))
+        {
+            crudTcs.TrySetException(new InvalidOperationException($"Gateway error: {error}"));
         }
 
         _requestToTenant.TryRemove(requestId, out _);
@@ -105,6 +230,12 @@ public class GatewayResponseCorrelator : IGatewayResponseCorrelator
             .Where(kvp => kvp.Value == tenantId)
             .Select(kvp => kvp.Key)
             .ToList();
+
+        if (requestIds.Count > 0)
+        {
+            logger.LogWarning("Cancelling {Count} pending requests for disconnected tenant {TenantId}",
+                requestIds.Count, tenantId);
+        }
 
         foreach (var requestId in requestIds)
         {

--- a/Everlore.Api/Gateway/IGatewayConnectionTracker.cs
+++ b/Everlore.Api/Gateway/IGatewayConnectionTracker.cs
@@ -14,6 +14,7 @@ public interface IGatewayConnectionTracker
     void UnregisterAgent(string connectionId);
     void UpdateHeartbeat(string connectionId, string agentVersion, IReadOnlyList<Guid> dataSourceIds);
     bool IsAgentOnline(Guid tenantId);
+    bool IsAgentHealthy(Guid tenantId);
     GatewayAgentInfo? GetAgentInfo(Guid tenantId);
     string? GetConnectionId(Guid tenantId);
 }

--- a/Everlore.Api/Gateway/IGatewayResponseCorrelator.cs
+++ b/Everlore.Api/Gateway/IGatewayResponseCorrelator.cs
@@ -6,8 +6,12 @@ public interface IGatewayResponseCorrelator
 {
     Task<GatewayExecuteQueryResponse> WaitForQueryResponseAsync(string requestId, TimeSpan timeout, CancellationToken ct = default);
     Task<GatewayDiscoverSchemaResponse> WaitForSchemaResponseAsync(string requestId, TimeSpan timeout, CancellationToken ct = default);
+    Task<GatewayExploreResponse> WaitForExploreResponseAsync(string requestId, TimeSpan timeout, CancellationToken ct = default);
+    Task<GatewayCrudResponse> WaitForCrudResponseAsync(string requestId, TimeSpan timeout, CancellationToken ct = default);
     void CompleteQueryResponse(string requestId, GatewayExecuteQueryResponse response);
     void CompleteSchemaResponse(string requestId, GatewayDiscoverSchemaResponse response);
+    void CompleteExploreResponse(string requestId, GatewayExploreResponse response);
+    void CompleteCrudResponse(string requestId, GatewayCrudResponse response);
     void FailRequest(string requestId, string error);
     void CancelPendingRequests(Guid tenantId);
     void RegisterRequestTenant(string requestId, Guid tenantId);

--- a/Everlore.AppHost/AppHost.cs
+++ b/Everlore.AppHost/AppHost.cs
@@ -81,6 +81,7 @@ var api = builder.AddProject<Projects.Everlore_Api>("everlore-api")
 builder.AddProject<Projects.Everlore_Gateway>("gateway")
     .WithEnvironment("Gateway__ServerUrl", api.GetEndpoint("https"))
     .WithEnvironment("Gateway__ApiKey", "dev-gateway-key")
+    .WithReference(everloretenantdb)
     .WithEnvironment("SIGNOZ_OTLP_ENDPOINT", signozCollector.GetEndpoint("grpc"))
     .WaitFor(api)
     .WaitFor(signozCollector);

--- a/Everlore.Application/Common/Interfaces/IExploreService.cs
+++ b/Everlore.Application/Common/Interfaces/IExploreService.cs
@@ -1,0 +1,7 @@
+namespace Everlore.Application.Common.Interfaces;
+
+public interface IExploreService
+{
+    Task<IReadOnlyList<Dictionary<string, object?>>> ExploreAsync(
+        Guid dataSourceId, int dataSourceType, string sql, CancellationToken ct = default);
+}

--- a/Everlore.Domain/Common/IRepository.cs
+++ b/Everlore.Domain/Common/IRepository.cs
@@ -13,4 +13,6 @@ public interface IRepository<T> where T : BaseEntity
     void Remove(T entity);
     void SetValues(T existing, T incoming);
     Task<int> SaveChangesAsync(CancellationToken ct = default);
+    Task<object> GetAllPagedAsync(int page, int pageSize, string? sortBy, string sortDir,
+        string? after, IDictionary<string, string>? filters, CancellationToken ct = default);
 }

--- a/Everlore.Gateway.Contracts/IGatewayHubClient.cs
+++ b/Everlore.Gateway.Contracts/IGatewayHubClient.cs
@@ -9,5 +9,7 @@ public interface IGatewayHubClient
 {
     Task ExecuteQuery(GatewayExecuteQueryRequest request);
     Task DiscoverSchema(GatewayDiscoverSchemaRequest request);
+    Task Explore(GatewayExploreRequest request);
+    Task ExecuteCrud(GatewayCrudRequest request);
     Task Ping();
 }

--- a/Everlore.Gateway.Contracts/IGatewayHubServer.cs
+++ b/Everlore.Gateway.Contracts/IGatewayHubServer.cs
@@ -10,6 +10,8 @@ public interface IGatewayHubServer
     Task<bool> Authenticate(string apiKey);
     Task SendQueryResult(GatewayExecuteQueryResponse response);
     Task SendSchemaResult(GatewayDiscoverSchemaResponse response);
+    Task SendExploreResult(GatewayExploreResponse response);
+    Task SendCrudResult(GatewayCrudResponse response);
     Task SendError(GatewayErrorResponse error);
     Task Heartbeat(GatewayHeartbeat heartbeat);
 }

--- a/Everlore.Gateway.Contracts/Messages/GatewayCrudPaginationParams.cs
+++ b/Everlore.Gateway.Contracts/Messages/GatewayCrudPaginationParams.cs
@@ -1,0 +1,9 @@
+namespace Everlore.Gateway.Contracts.Messages;
+
+public record GatewayCrudPaginationParams(
+    int Page,
+    int PageSize,
+    string? SortBy,
+    string SortDir,
+    string? After,
+    Dictionary<string, string>? Filters);

--- a/Everlore.Gateway.Contracts/Messages/GatewayCrudRequest.cs
+++ b/Everlore.Gateway.Contracts/Messages/GatewayCrudRequest.cs
@@ -1,0 +1,19 @@
+namespace Everlore.Gateway.Contracts.Messages;
+
+public record GatewayCrudRequest(
+    string RequestId,
+    string EntityType,
+    CrudOperation Operation,
+    Guid? EntityId,
+    string? EntityJson,
+    string? PaginationJson,
+    string? After);
+
+public enum CrudOperation
+{
+    GetAll,
+    GetById,
+    Create,
+    Update,
+    Delete
+}

--- a/Everlore.Gateway.Contracts/Messages/GatewayCrudResponse.cs
+++ b/Everlore.Gateway.Contracts/Messages/GatewayCrudResponse.cs
@@ -1,0 +1,8 @@
+namespace Everlore.Gateway.Contracts.Messages;
+
+public record GatewayCrudResponse(
+    string RequestId,
+    bool Success,
+    string? ResultJson,
+    int StatusCode,
+    string? Error);

--- a/Everlore.Gateway.Contracts/Messages/GatewayExploreRequest.cs
+++ b/Everlore.Gateway.Contracts/Messages/GatewayExploreRequest.cs
@@ -1,0 +1,3 @@
+namespace Everlore.Gateway.Contracts.Messages;
+
+public record GatewayExploreRequest(string RequestId, Guid DataSourceId, int DataSourceType, string Sql);

--- a/Everlore.Gateway.Contracts/Messages/GatewayExploreResponse.cs
+++ b/Everlore.Gateway.Contracts/Messages/GatewayExploreResponse.cs
@@ -1,0 +1,3 @@
+namespace Everlore.Gateway.Contracts.Messages;
+
+public record GatewayExploreResponse(string RequestId, bool Success, string? ResultJson, int RowCount, string? Error);

--- a/Everlore.Gateway/Configuration/GatewaySettings.cs
+++ b/Everlore.Gateway/Configuration/GatewaySettings.cs
@@ -6,6 +6,7 @@ public class GatewaySettings
     public string ApiKey { get; set; } = string.Empty;
     public int ReconnectDelaySeconds { get; set; } = 5;
     public int HeartbeatIntervalSeconds { get; set; } = 30;
+    public string? TenantDbConnectionString { get; set; }
     public Dictionary<string, DataSourceLocalConfig> DataSources { get; set; } = new();
 }
 

--- a/Everlore.Gateway/Everlore.Gateway.csproj
+++ b/Everlore.Gateway/Everlore.Gateway.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Everlore.Gateway.Contracts\Everlore.Gateway.Contracts.csproj" />
+    <ProjectReference Include="..\Everlore.Infrastructure.Postgres\Everlore.Infrastructure.Postgres.csproj" />
     <ProjectReference Include="..\Everlore.QueryEngine\Everlore.QueryEngine.csproj" />
     <ProjectReference Include="..\Everlore.ServiceDefaults\Everlore.ServiceDefaults.csproj" />
   </ItemGroup>

--- a/Everlore.Gateway/Handlers/CrudHandler.cs
+++ b/Everlore.Gateway/Handlers/CrudHandler.cs
@@ -1,0 +1,189 @@
+using System.Text.Json;
+using Everlore.Application.Common.Extensions;
+using Everlore.Application.Common.Models;
+using Everlore.Domain.AccountsPayable;
+using Everlore.Domain.AccountsReceivable;
+using Everlore.Domain.Common;
+using Everlore.Domain.Inventory;
+using Everlore.Domain.Sales;
+using Everlore.Domain.Shipping;
+using Everlore.Gateway.Contracts.Messages;
+using Everlore.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Everlore.Gateway.Handlers;
+
+public class CrudHandler(
+    IServiceProvider serviceProvider,
+    ILogger<CrudHandler> logger)
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    private static readonly Dictionary<string, Type> EntityTypeMap = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Vendor"] = typeof(Vendor),
+        ["Bill"] = typeof(Bill),
+        ["Customer"] = typeof(Customer),
+        ["Invoice"] = typeof(Invoice),
+        ["Product"] = typeof(Product),
+        ["Warehouse"] = typeof(Warehouse),
+        ["SalesOrder"] = typeof(SalesOrder),
+        ["Carrier"] = typeof(Carrier),
+        ["Shipment"] = typeof(Shipment)
+    };
+
+    public async Task<GatewayCrudResponse> HandleAsync(GatewayCrudRequest request, CancellationToken ct)
+    {
+        try
+        {
+            logger.LogInformation("Handling CRUD {Operation} for {EntityType} (request {RequestId})",
+                request.Operation, request.EntityType, request.RequestId);
+
+            if (!EntityTypeMap.TryGetValue(request.EntityType, out var entityType))
+                return new GatewayCrudResponse(request.RequestId, false, null, 400, $"Unknown entity type: {request.EntityType}");
+
+            using var scope = serviceProvider.CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<EverloreDbContext>();
+
+            return request.Operation switch
+            {
+                CrudOperation.GetAll => await HandleGetAll(dbContext, entityType, request, ct),
+                CrudOperation.GetById => await HandleGetById(dbContext, entityType, request, ct),
+                CrudOperation.Create => await HandleCreate(dbContext, entityType, request, ct),
+                CrudOperation.Update => await HandleUpdate(dbContext, entityType, request, ct),
+                CrudOperation.Delete => await HandleDelete(dbContext, entityType, request, ct),
+                _ => new GatewayCrudResponse(request.RequestId, false, null, 400, $"Unknown operation: {request.Operation}")
+            };
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "CRUD {Operation} for {EntityType} (request {RequestId}) failed",
+                request.Operation, request.EntityType, request.RequestId);
+            return new GatewayCrudResponse(request.RequestId, false, null, 500, ex.Message);
+        }
+    }
+
+    private async Task<GatewayCrudResponse> HandleGetAll(
+        EverloreDbContext dbContext, Type entityType, GatewayCrudRequest request, CancellationToken ct)
+    {
+        // Use reflection to call the generic method
+        var method = typeof(CrudHandler).GetMethod(nameof(GetAllTyped),
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+        var generic = method.MakeGenericMethod(entityType);
+        var result = await (Task<object>)generic.Invoke(null, [dbContext, request, ct])!;
+
+        var json = JsonSerializer.Serialize(result, JsonOptions);
+        return new GatewayCrudResponse(request.RequestId, true, json, 200, null);
+    }
+
+    private static async Task<object> GetAllTyped<T>(
+        EverloreDbContext dbContext, GatewayCrudRequest request, CancellationToken ct) where T : BaseEntity
+    {
+        var query = dbContext.Set<T>().AsQueryable();
+
+        GatewayCrudPaginationParams? pagination = null;
+        if (!string.IsNullOrWhiteSpace(request.PaginationJson))
+        {
+            pagination = JsonSerializer.Deserialize<GatewayCrudPaginationParams>(request.PaginationJson,
+                new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, PropertyNameCaseInsensitive = true });
+        }
+
+        var page = pagination?.Page ?? 1;
+        var pageSize = pagination?.PageSize ?? 25;
+        var sortBy = pagination?.SortBy;
+        var sortDir = pagination?.SortDir ?? "asc";
+        var after = pagination?.After;
+        var filters = pagination?.Filters is not null
+            ? new Dictionary<string, string>(pagination.Filters, StringComparer.OrdinalIgnoreCase)
+            : null;
+
+        if (!string.IsNullOrWhiteSpace(after))
+        {
+            var cursorQuery = new CursorPaginationQuery(pageSize, after, sortBy, sortDir);
+            return await query.ToCursorPagedResultAsync(cursorQuery, filters, ct);
+        }
+
+        var paginationQuery = new PaginationQuery(page, pageSize, sortBy, sortDir);
+        return await query.ToPagedResultAsync(paginationQuery, filters, ct);
+    }
+
+    private async Task<GatewayCrudResponse> HandleGetById(
+        EverloreDbContext dbContext, Type entityType, GatewayCrudRequest request, CancellationToken ct)
+    {
+        if (!request.EntityId.HasValue)
+            return new GatewayCrudResponse(request.RequestId, false, null, 400, "EntityId required for GetById");
+
+        var entity = await dbContext.FindAsync(entityType, [request.EntityId.Value], ct);
+
+        if (entity is null)
+            return new GatewayCrudResponse(request.RequestId, false, null, 404, "Entity not found");
+
+        var json = JsonSerializer.Serialize(entity, entityType, JsonOptions);
+        return new GatewayCrudResponse(request.RequestId, true, json, 200, null);
+    }
+
+    private async Task<GatewayCrudResponse> HandleCreate(
+        EverloreDbContext dbContext, Type entityType, GatewayCrudRequest request, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(request.EntityJson))
+            return new GatewayCrudResponse(request.RequestId, false, null, 400, "EntityJson required for Create");
+
+        var entity = (BaseEntity)JsonSerializer.Deserialize(request.EntityJson, entityType, JsonOptions)!;
+
+        if (entity.Id == Guid.Empty)
+            entity.Id = Guid.NewGuid();
+
+        dbContext.Add(entity);
+        await dbContext.SaveChangesAsync(ct);
+
+        var json = JsonSerializer.Serialize(entity, entityType, JsonOptions);
+        return new GatewayCrudResponse(request.RequestId, true, json, 201, null);
+    }
+
+    private async Task<GatewayCrudResponse> HandleUpdate(
+        EverloreDbContext dbContext, Type entityType, GatewayCrudRequest request, CancellationToken ct)
+    {
+        if (!request.EntityId.HasValue || string.IsNullOrWhiteSpace(request.EntityJson))
+            return new GatewayCrudResponse(request.RequestId, false, null, 400, "EntityId and EntityJson required for Update");
+
+        var existing = await dbContext.FindAsync(entityType, [request.EntityId.Value], ct);
+        if (existing is null)
+            return new GatewayCrudResponse(request.RequestId, false, null, 404, "Entity not found");
+
+        var incoming = (BaseEntity)JsonSerializer.Deserialize(request.EntityJson, entityType, JsonOptions)!;
+
+        // Preserve audit fields
+        var existingEntity = (BaseEntity)existing;
+        var createdAt = existingEntity.CreatedAt;
+        var createdBy = existingEntity.CreatedBy;
+
+        dbContext.Entry(existing).CurrentValues.SetValues(incoming);
+
+        existingEntity.Id = request.EntityId.Value;
+        existingEntity.CreatedAt = createdAt;
+        existingEntity.CreatedBy = createdBy;
+
+        await dbContext.SaveChangesAsync(ct);
+        return new GatewayCrudResponse(request.RequestId, true, null, 204, null);
+    }
+
+    private async Task<GatewayCrudResponse> HandleDelete(
+        EverloreDbContext dbContext, Type entityType, GatewayCrudRequest request, CancellationToken ct)
+    {
+        if (!request.EntityId.HasValue)
+            return new GatewayCrudResponse(request.RequestId, false, null, 400, "EntityId required for Delete");
+
+        var entity = await dbContext.FindAsync(entityType, [request.EntityId.Value], ct);
+        if (entity is null)
+            return new GatewayCrudResponse(request.RequestId, false, null, 404, "Entity not found");
+
+        dbContext.Remove(entity);
+        await dbContext.SaveChangesAsync(ct);
+        return new GatewayCrudResponse(request.RequestId, true, null, 204, null);
+    }
+}

--- a/Everlore.Gateway/Handlers/ExploreHandler.cs
+++ b/Everlore.Gateway/Handlers/ExploreHandler.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using Dapper;
+using Everlore.Domain.Reporting;
+using Everlore.Gateway.Contracts.Messages;
+using Everlore.QueryEngine.Connections;
+using Microsoft.Extensions.Logging;
+
+namespace Everlore.Gateway.Handlers;
+
+public class ExploreHandler(
+    IExternalConnectionFactory connectionFactory,
+    ILogger<ExploreHandler> logger)
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    public async Task<GatewayExploreResponse> HandleAsync(GatewayExploreRequest request, CancellationToken ct)
+    {
+        try
+        {
+            logger.LogInformation("Executing explore {RequestId} for data source {DataSourceId}",
+                request.RequestId, request.DataSourceId);
+
+            var dataSource = new DataSource
+            {
+                Id = request.DataSourceId,
+                Type = (DataSourceType)request.DataSourceType
+            };
+
+            using var connection = await connectionFactory.CreateConnectionAsync(dataSource, ct);
+            var rows = (await connection.QueryAsync(request.Sql)).ToList();
+
+            var results = rows.Select(r =>
+            {
+                var dict = (IDictionary<string, object?>)r;
+                return dict.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            }).ToList();
+
+            var resultJson = JsonSerializer.Serialize(results, JsonOptions);
+
+            logger.LogInformation("Explore {RequestId} completed: {RowCount} rows",
+                request.RequestId, results.Count);
+
+            return new GatewayExploreResponse(request.RequestId, true, resultJson, results.Count, null);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Explore {RequestId} failed", request.RequestId);
+            return new GatewayExploreResponse(request.RequestId, false, null, 0, ex.Message);
+        }
+    }
+}

--- a/Everlore.Infrastructure/DependencyInjection.cs
+++ b/Everlore.Infrastructure/DependencyInjection.cs
@@ -29,15 +29,25 @@ public static class DependencyInjection
         services.AddSingleton<IEncryptionService, DataProtectionEncryptionService>();
 
         // Generic repositories (used by CrudController<T>)
-        services.AddScoped<IRepository<Vendor>, Repository<Vendor>>();
-        services.AddScoped<IRepository<Bill>, Repository<Bill>>();
-        services.AddScoped<IRepository<Customer>, Repository<Customer>>();
-        services.AddScoped<IRepository<Invoice>, Repository<Invoice>>();
-        services.AddScoped<IRepository<Product>, Repository<Product>>();
-        services.AddScoped<IRepository<Warehouse>, Repository<Warehouse>>();
-        services.AddScoped<IRepository<SalesOrder>, Repository<SalesOrder>>();
-        services.AddScoped<IRepository<Carrier>, Repository<Carrier>>();
-        services.AddScoped<IRepository<Shipment>, Repository<Shipment>>();
+        // Concrete Repository<T> registered for direct resolution and gateway decorator wrapping
+        services.AddScoped<Repository<Vendor>>();
+        services.AddScoped<Repository<Bill>>();
+        services.AddScoped<Repository<Customer>>();
+        services.AddScoped<Repository<Invoice>>();
+        services.AddScoped<Repository<Product>>();
+        services.AddScoped<Repository<Warehouse>>();
+        services.AddScoped<Repository<SalesOrder>>();
+        services.AddScoped<Repository<Carrier>>();
+        services.AddScoped<Repository<Shipment>>();
+        services.AddScoped<IRepository<Vendor>>(sp => sp.GetRequiredService<Repository<Vendor>>());
+        services.AddScoped<IRepository<Bill>>(sp => sp.GetRequiredService<Repository<Bill>>());
+        services.AddScoped<IRepository<Customer>>(sp => sp.GetRequiredService<Repository<Customer>>());
+        services.AddScoped<IRepository<Invoice>>(sp => sp.GetRequiredService<Repository<Invoice>>());
+        services.AddScoped<IRepository<Product>>(sp => sp.GetRequiredService<Repository<Product>>());
+        services.AddScoped<IRepository<Warehouse>>(sp => sp.GetRequiredService<Repository<Warehouse>>());
+        services.AddScoped<IRepository<SalesOrder>>(sp => sp.GetRequiredService<Repository<SalesOrder>>());
+        services.AddScoped<IRepository<Carrier>>(sp => sp.GetRequiredService<Repository<Carrier>>());
+        services.AddScoped<IRepository<Shipment>>(sp => sp.GetRequiredService<Repository<Shipment>>());
 
         return services;
     }

--- a/Everlore.Infrastructure/Persistence/Repository.cs
+++ b/Everlore.Infrastructure/Persistence/Repository.cs
@@ -1,3 +1,5 @@
+using Everlore.Application.Common.Extensions;
+using Everlore.Application.Common.Models;
 using Everlore.Domain.Common;
 using Microsoft.EntityFrameworkCore;
 
@@ -36,4 +38,19 @@ public class Repository<T>(EverloreDbContext context) : IRepository<T> where T :
 
     public Task<int> SaveChangesAsync(CancellationToken ct = default)
         => Context.SaveChangesAsync(ct);
+
+    public async Task<object> GetAllPagedAsync(int page, int pageSize, string? sortBy, string sortDir,
+        string? after, IDictionary<string, string>? filters, CancellationToken ct = default)
+    {
+        var query = Query();
+
+        if (!string.IsNullOrWhiteSpace(after))
+        {
+            var cursorQuery = new CursorPaginationQuery(pageSize, after, sortBy, sortDir);
+            return await query.ToCursorPagedResultAsync(cursorQuery, filters, ct);
+        }
+
+        var pagination = new PaginationQuery(page, pageSize, sortBy, sortDir);
+        return await query.ToPagedResultAsync(pagination, filters, ct);
+    }
 }

--- a/Everlore.QueryEngine/DependencyInjection.cs
+++ b/Everlore.QueryEngine/DependencyInjection.cs
@@ -44,6 +44,7 @@ public static class DependencyInjection
 
         // GraphQL
         services.AddScoped<DynamicQueryResolver>();
+        services.AddScoped<LocalExploreService>();
 
         // Resilience pipeline
         services.AddResiliencePipeline("external-db", builder =>

--- a/Everlore.QueryEngine/GraphQL/ExploreSqlBuilder.cs
+++ b/Everlore.QueryEngine/GraphQL/ExploreSqlBuilder.cs
@@ -1,0 +1,50 @@
+using System.Text;
+using Everlore.Domain.Reporting;
+using Everlore.QueryEngine.Schema;
+using HotChocolate.Resolvers;
+
+namespace Everlore.QueryEngine.GraphQL;
+
+public static class ExploreSqlBuilder
+{
+    public static string BuildExploreSql(IResolverContext context, DataSource dataSource, DiscoveredTable table)
+    {
+        var selectedFields = context.Selection.SyntaxNode.SelectionSet?.Selections
+            .OfType<HotChocolate.Language.FieldNode>()
+            .Select(f => f.Name.Value)
+            .ToList() ?? [];
+
+        var validColumns = table.Columns.Select(c => c.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var selectColumns = selectedFields.Count > 0
+            ? selectedFields.Where(validColumns.Contains).ToList()
+            : table.Columns.Select(c => c.Name).ToList();
+
+        if (selectColumns.Count == 0)
+            selectColumns = table.Columns.Select(c => c.Name).ToList();
+
+        var quote = GetQuoteFunc(dataSource.Type);
+
+        var sb = new StringBuilder("SELECT ");
+        sb.Append(string.Join(", ", selectColumns.Select(quote)));
+        sb.Append(" FROM ");
+        sb.Append($"{quote(table.SchemaName)}.{quote(table.TableName)}");
+
+        var firstArg = context.ArgumentValue<int?>("first");
+        var first = firstArg ?? 100;
+        first = Math.Min(first, 1000);
+        sb.Append(dataSource.Type == DataSourceType.SqlServer
+            ? $" ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH NEXT {first} ROWS ONLY"
+            : $" LIMIT {first}");
+
+        return sb.ToString();
+    }
+
+    private static Func<string, string> GetQuoteFunc(DataSourceType type) => type switch
+    {
+        DataSourceType.PostgreSql => s => $"\"{s}\"",
+        DataSourceType.SqlServer => s => $"[{s}]",
+        DataSourceType.MySql => s => $"`{s}`",
+        _ => s => $"\"{s}\""
+    };
+}

--- a/Everlore.QueryEngine/GraphQL/LocalExploreService.cs
+++ b/Everlore.QueryEngine/GraphQL/LocalExploreService.cs
@@ -1,0 +1,29 @@
+using System.Data;
+using Dapper;
+using Everlore.Application.Common.Interfaces;
+using Everlore.Domain.Reporting;
+using Everlore.QueryEngine.Connections;
+
+namespace Everlore.QueryEngine.GraphQL;
+
+public class LocalExploreService(IExternalConnectionFactory connectionFactory) : IExploreService
+{
+    public async Task<IReadOnlyList<Dictionary<string, object?>>> ExploreAsync(
+        Guid dataSourceId, int dataSourceType, string sql, CancellationToken ct = default)
+    {
+        var dataSource = new DataSource
+        {
+            Id = dataSourceId,
+            Type = (DataSourceType)dataSourceType
+        };
+
+        using var connection = await connectionFactory.CreateConnectionAsync(dataSource, ct);
+        var rows = (await connection.QueryAsync(sql)).ToList();
+
+        return rows.Select(r =>
+        {
+            var dict = (IDictionary<string, object?>)r;
+            return dict.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        }).ToList();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -133,13 +133,16 @@ Phase 1 (Platform Hardening) is complete. Phase 2 (Reporting API) is in progress
 - Serilog structured logging with OTLP export to Aspire Dashboard and SigNoz
 - SigNoz observability stack (ClickHouse, OTel Collector, Query Service, Frontend) as Aspire containers
 - **Gateway agent system** for querying customer databases on remote networks via outbound SignalR
+- **Gateway hardening** — heartbeat freshness checking, structured correlator/hub logging
+- **GraphQL gateway routing** — explore queries for self-hosted tenants route through the gateway agent
+- **Tenant DB CRUD proxying** — CRUD operations for self-hosted tenants route through the gateway agent
 
 See [ROADMAP.md](ROADMAP.md) for the full development plan with detailed progress.
 
 ## Roadmap
 
 1. **Platform Hardening** — Pagination, filtering, cursor pagination, correlation IDs, audit trail, tenant provisioning, tenant settings *(complete)*
-2. **Reporting API & Ad-Hoc Query Engine** — Data sources, schema discovery, query model, SQL translation, GraphQL, SignalR, gateway agent *(complete except export)*
+2. **Reporting API & Ad-Hoc Query Engine** — Data sources, schema discovery, query model, SQL translation, GraphQL, SignalR, gateway agent, CRUD proxying *(complete except export)*
 3. **Frontend & Dashboard Builder** — React/Next.js report builder, dashboards, interactive filtering
 4. **AI Integration** — Provider abstraction, natural language to query, data-aware chat
 5. **Data Pipeline & Connectors** — Connector SDK, QuickBooks/Xero, scheduled sync

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -132,8 +132,13 @@ The core product. Users connect to external databases, browse schemas, build que
 - [x] Gateway status endpoint: `GET /api/tenants/{id}/gateway-status` (online/offline, version, health)
 - [x] Aspire integration: gateway agent as Aspire project with dev seeded self-hosted tenant
 - [x] Heartbeat monitoring with health status based on heartbeat freshness
-- [ ] Full GraphQL gateway routing (follow-up: currently REST query API only for self-hosted)
-- [ ] Tenant DB CRUD proxying for on-prem business data storage (follow-up)
+- [x] Heartbeat freshness checking (90s threshold) in connection tracker; `IsAgentHealthy` method
+- [x] Structured logging in `GatewayResponseCorrelator` (waiter registration, completion, timeout, orphaned responses, disconnect cancellation)
+- [x] Hub logging improvements: trace-level heartbeat logging, connection duration on disconnect
+- [x] GraphQL explore gateway routing: `IExploreService` abstraction, `ExploreSqlBuilder`, `LocalExploreService`, `GatewayExploreService` decorator, agent `ExploreHandler`
+- [x] Tenant DB CRUD proxying: `GatewayRepository<T>` decorator, `GatewayCrudService`, agent `CrudHandler`, `GetAllPagedAsync` on `IRepository<T>`
+- [x] `Everlore.Gateway.Contracts` extended: `GatewayExploreRequest/Response`, `GatewayCrudRequest/Response`, `GatewayCrudPaginationParams`
+- [x] Gateway agent: optional `EverloreDbContext` with `TenantDbConnectionString` config for CRUD operations
 
 ### 2.9 Export — not started
 - CSV and Excel export from query results


### PR DESCRIPTION
## Summary

- **Gateway hardening**: Heartbeat freshness checking (90s threshold), structured logging in `GatewayResponseCorrelator` (waiter lifecycle, timeouts, orphaned responses), trace-level heartbeat logging and connection duration on disconnect in `GatewayHub`
- **GraphQL explore gateway routing**: `IExploreService` abstraction with `LocalExploreService` (Dapper direct) and `GatewayExploreService` decorator that routes SelfHosted tenants through SignalR to the agent's `ExploreHandler`; `ExploreSqlBuilder` extracted from `DynamicQueryResolver`
- **Tenant DB CRUD proxying**: `GatewayRepository<T>` decorator wraps `Repository<T>` and routes SelfHosted tenant CRUD through `GatewayCrudService` → SignalR → agent `CrudHandler`; `GetAllPagedAsync` added to `IRepository<T>` so pagination params travel to the agent; gateway agent optionally registers `EverloreDbContext` when `TenantDbConnectionString` is configured

## Test plan

- [x] `dotnet build Everlore.slnx` — zero errors
- [x] Set Serilog min to Trace, observe heartbeat trace logs; disconnect agent and verify cancellation warning logs with request counts
- [x] Run GraphQL `explore` query against self-hosted data source — verify gateway routing returns rows
- [x] Hit `GET /api/products` for self-hosted tenant — verify gateway routing; create/update/delete entities round-trip
- [x] Verify SaasHosted tenants are unaffected (all operations still delegate to inner implementations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)